### PR TITLE
Add support for WikiNames

### DIFF
--- a/lib/markupparser/markupparser.tcl
+++ b/lib/markupparser/markupparser.tcl
@@ -298,8 +298,14 @@ proc ::markupparser::parse {text} {
                     }
                 }
             }
+
+            # NEXT handle WikiNames autolinks
+            if {[regexp {^((?:[A-Z][a-z0-9]+){2,})(.*)$} $para -> link para]} {
+                lappend result LINK $link
+                continue
+            }   
             
-            if {![regexp {^(.[^'<\[]*)(['<\[].*)$} $para dummy elem para]} {
+            if {![regexp {^(.[^'<\[A-Z]*)(['<\[A-Z].*)$} $para dummy elem para]} {
                 set elem $para
                 set para ""
             }


### PR DESCRIPTION
Add support for the original WikiNames. This will autolink any CamelCase words. Feel free to ignore if you don't see the value.